### PR TITLE
Release 0.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_call]
 
 jobs:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = [
     "setuptools>=42",
+    "setuptools-scm",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = pytest-rich
-version = 0.1.0
 author = Bruno Oliveira
 author_email = nicoddemus@gmail.com
 maintainer = Bruno Oliveira


### PR DESCRIPTION
I released `0.1.0` just now in order for the PyPI project to be created, so I could create an API token for it (#15).

Also use `setuptools-scm` for versioning: this allow us to publish using tags to the repository.

I plan to release `0.1.1` just to test the workflow works.