### PR TITLE
Adjust test workflow to not build on tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish Python Package
+name: publish
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: test
 
-on: [push, pull_request, workflow_call]
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+  workflow_call:
 
 jobs:
 


### PR DESCRIPTION
In #25 I noticed pushing a tag would run the entire 'test' workflow again, which is a waste because 'publish' also runs the tests.

Also renamed the 'publish' workflow to match the same style used in 'test'.