### PR TITLE
Add initial example tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,10 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+
+[tool.pytest.ini_options]
+addopts = "--ignore tests/example"
+pytester_example_dir = "tests/example"
+testpaths = [
+  "tests",
+]

--- a/tests/example/test_basic.py
+++ b/tests/example/test_basic.py
@@ -1,0 +1,28 @@
+import pytest
+
+
+def test_pass():
+    assert True
+
+
+def test_fail():
+    assert False
+
+
+def test_error():
+    raise Exception("error")
+
+
+@pytest.mark.skip(reason="skipped")
+def test_skip():
+    ...
+
+
+@pytest.mark.xfail(reason="xfail")
+def test_xfail():
+    assert False
+
+
+@pytest.mark.xfail(reason="xpass")
+def test_xpass():
+    assert True


### PR DESCRIPTION
Scaffolding out the initial example tests so we can start using the `pytester` plugin to actually test the output of `pytest-rich`.

I chose to split the example code out into its own file instead of inlining so one could call the tests manually from the command line using `pytest --rich tests/example`.