### PR TITLE
Switch from depreciated hook to new `hookimpl`

### DIFF
--- a/src/pytest_rich/plugin.py
+++ b/src/pytest_rich/plugin.py
@@ -12,10 +12,9 @@ def pytest_addoption(parser):
     parser.addoption("--rich", action="store_true", default=False)
 
 
-@pytest.mark.trylast
+@pytest.mark.hookimpl(trylast=True)
 def pytest_configure(config):
     if sys.stdout.isatty() and config.getoption("rich"):
-        # Get the standard terminal reporter plugin and replace it with ours
         standard_reporter = config.pluginmanager.getplugin("terminalreporter")
         config.pluginmanager.unregister(standard_reporter)
         config.pluginmanager.register(


### PR DESCRIPTION
Re: #45 -- That issue came about because this package was using a depreciated way of using Pytest hooks.