### PR TITLE
remove extraneous `mark`

### DIFF
--- a/src/pytest_rich/plugin.py
+++ b/src/pytest_rich/plugin.py
@@ -12,7 +12,7 @@ def pytest_addoption(parser):
     parser.addoption("--rich", action="store_true", default=False)
 
 
-@pytest.mark.hookimpl(trylast=True)
+@pytest.hookimpl(trylast=True)
 def pytest_configure(config):
     if sys.stdout.isatty() and config.getoption("rich"):
         standard_reporter = config.pluginmanager.getplugin("terminalreporter")


### PR DESCRIPTION
An oversight on a previous PR, the correct syntax for the new hook registration does not contain `mark`, caused an `INTERNALERROR`.

## Traceback
```python
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/josh/.pyenv/versions/3.10.6/envs/pytest-rich-3.10.6/lib/python3.10/site-packages/_pytest/main.py", line 266, in wrap_session
INTERNALERROR>     config._do_configure()
INTERNALERROR>   File "/home/josh/.pyenv/versions/3.10.6/envs/pytest-rich-3.10.6/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1037, in _do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>   File "/home/josh/.pyenv/versions/3.10.6/envs/pytest-rich-3.10.6/lib/python3.10/site-packages/pluggy/_hooks.py", line 277, in call_historic
INTERNALERROR>     res = self._hookexec(self.name, self.get_hookimpls(), kwargs, False)
INTERNALERROR>   File "/home/josh/.pyenv/versions/3.10.6/envs/pytest-rich-3.10.6/lib/python3.10/site-packages/pluggy/_manager.py", line 80, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>   File "/home/josh/.pyenv/versions/3.10.6/envs/pytest-rich-3.10.6/lib/python3.10/site-packages/pluggy/_callers.py", line 60, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/josh/.pyenv/versions/3.10.6/envs/pytest-rich-3.10.6/lib/python3.10/site-packages/pluggy/_result.py", line 60, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/josh/.pyenv/versions/3.10.6/envs/pytest-rich-3.10.6/lib/python3.10/site-packages/pluggy/_callers.py", line 39, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/josh/projects/pytest-rich/src/pytest_rich/plugin.py", line 31, in pytest_configure
INTERNALERROR>     config.pluginmanager.unregister(plugin=standard_reporter)
INTERNALERROR>   File "/home/josh/.pyenv/versions/3.10.6/envs/pytest-rich-3.10.6/lib/python3.10/site-packages/pluggy/_manager.py", line 137, in unregister
INTERNALERROR>     assert plugin is not None, "one of name or plugin needs to be specified"
INTERNALERROR> AssertionError: one of name or plugin needs to be specified
```