### PR TITLE
Add Python 3.11 support to trove classifiers and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [#40]: Added `CHANGELOG.md` file.
+- [#39]: Confirmed Python 3.11 support.
 - [#31]: Added test summary to the end of the test run.
 
 ## [0.1.1] - 2022-03-03
@@ -39,4 +40,5 @@ Initial release!
 <!-- PR links -->
 
 [#31]: https://github.com/nicoddemus/pytest-rich/pull/31
+[#39]: https://github.com/nicoddemus/pytest-rich/pull/39
 [#40]: https://github.com/nicoddemus/pytest-rich/pull/40

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy


### PR DESCRIPTION
Python 3.11 was added to CI in a previous PR (#39), but not updated in the trove classifiers or added to the CHANGELOG.