### PR TITLE
migrate to `pyproject.toml` only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,11 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "setuptools-scm",
-    "wheel"
-]
+requires = ["setuptools>=42", "setuptools-scm", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 
-[tool.isort]
-profile = "black"
-force_single_line = "true"
 
 [tool.pytest.ini_options]
 addopts = "--ignore tests/example"
 pytester_example_dir = "tests/example"
-testpaths = [
-  "tests",
-]
+testpaths = ["tests"]

--- a/src/pytest_rich/capture.py
+++ b/src/pytest_rich/capture.py
@@ -1,6 +1,5 @@
 import re
-from datetime import datetime
-from datetime import timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Tuple
 

--- a/src/pytest_rich/header.py
+++ b/src/pytest_rich/header.py
@@ -1,6 +1,5 @@
 import sys
-from typing import Iterable
-from typing import Union
+from typing import Iterable, Union
 
 import pytest
 from _pytest.main import Session

--- a/src/pytest_rich/terminal.py
+++ b/src/pytest_rich/terminal.py
@@ -2,24 +2,16 @@ import sys
 import warnings
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Sequence
-from typing import Tuple
-from typing import Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import attr
 import pytest
-from _pytest._code.code import ExceptionChainRepr
-from _pytest._code.code import ExceptionRepr
+from _pytest._code.code import ExceptionChainRepr, ExceptionRepr
 from rich.console import Console
 from rich.live import Live
 from rich.padding import Padding
 from rich.panel import Panel
-from rich.progress import Progress
-from rich.progress import SpinnerColumn
-from rich.progress import TaskID
+from rich.progress import Progress, SpinnerColumn, TaskID
 from rich.rule import Rule
 from rich.table import Table
 from rich.text import Text

--- a/src/pytest_rich/traceback.py
+++ b/src/pytest_rich/traceback.py
@@ -1,34 +1,21 @@
 import ast
 import sys
-from typing import Dict
-from typing import Optional
-from typing import Sequence
+from typing import Dict, Optional, Sequence
 
 import attr
-from _pytest._code.code import ExceptionChainRepr
-from _pytest._code.code import ReprEntry
-from _pytest._code.code import ReprFileLocation
-from _pytest._code.code import ReprFuncArgs
-from pygments.token import Comment
-from pygments.token import Keyword
-from pygments.token import Name
-from pygments.token import Number
-from pygments.token import Operator
-from pygments.token import String
+from _pytest._code.code import (ExceptionChainRepr, ReprEntry,
+                                ReprFileLocation, ReprFuncArgs)
+from pygments.token import Comment, Keyword, Name, Number, Operator, String
 from pygments.token import Text as TextToken
 from pygments.token import Token
 from rich._loop import loop_last
-from rich.console import Console
-from rich.console import ConsoleOptions
-from rich.console import ConsoleRenderable
-from rich.console import RenderResult
-from rich.console import group
+from rich.console import (Console, ConsoleOptions, ConsoleRenderable,
+                          RenderResult, group)
 from rich.highlighter import ReprHighlighter
 from rich.panel import Panel
 from rich.rule import Rule
 from rich.style import Style
-from rich.syntax import Syntax
-from rich.syntax import SyntaxTheme
+from rich.syntax import Syntax, SyntaxTheme
 from rich.text import Text
 from rich.theme import Theme
 from rich.traceback import PathHighlighter

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -1,5 +1,4 @@
-from datetime import datetime
-from datetime import timezone
+from datetime import datetime, timezone
 
 import pytest
 from freezegun import freeze_time


### PR DESCRIPTION
I've adopted a `pyproject.toml` only approach for all of my Python packages at my day job and for my personal ones as well.

closes #53 