### PR TITLE
Drop Python 3.7 and add Python 3.12

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.x"
       - name: Get pip cache dir
         id: pip-cache
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox tox-gh-actions
+          python -m pip install tox
       - name: Test
         run: |
-          tox
+          tox -e py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.7", "pypy-3.8"]
+          ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.4.0
+    rev: 24.4.2
     hooks:
       - id: black
         args: [--safe, --quiet]
@@ -36,7 +36,7 @@ repos:
       - id: isort
         name: isort
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.10.1
     hooks:
       - id: mypy
         language_version: python3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Confirmed Python 3.12 support. ([#84])
 - Added `CHANGELOG.md` file. ([#40])
 - Confirmed Python 3.11 support. ([#39])
 - Added test summary to the end of the test run. ([#31])
 - Added support for `--no-header` and `--no-summary` command line options. ([#64])
 - Added support for capturing terminal output using Rich's `Console` class, with command line option `--rich-capture`. ([#65])
 - Added support for other plugins to add to test header, through invocation of `pytest_report_header` hook. ([#66])
+
+### Removed
+
+- Dropped Python 3.7 support. ([#84])
+
 
 ## [0.1.1] - 2022-03-03
 
@@ -48,3 +54,4 @@ Initial release!
 [#64]: https://github.com/nicoddemus/pytest-rich/pull/64
 [#65]: https://github.com/nicoddemus/pytest-rich/pull/65
 [#66]: https://github.com/nicoddemus/pytest-rich/pull/66
+[#84]: https://github.com/nicoddemus/pytest-rich/pull/84

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,11 +15,11 @@ classifiers =
     Topic :: Software Development :: Testing
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
@@ -44,6 +44,7 @@ dev =
     flake8
     freezegun
     mypy
+    pre-commit
     reorder-python-imports
     tox
     types-attrs

--- a/tox.ini
+++ b/tox.ini
@@ -5,15 +5,6 @@ envlist =
     flake8
 isolated_build = true
 
-[gh-actions]
-python =
-    3.8: py38
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    3.12: py312
-    pypy-3.8: pypy38
-
 [testenv]
 deps =
     freezegun

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,17 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
 envlist =
-    py{37,38,39,310,311,py37,py38}
+    py{37,38,39,310,311,312,py38}
     flake8
 isolated_build = true
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
-    pypy-3.7: pypy37
+    3.12: py312
     pypy-3.8: pypy38
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 [tox]
 envlist =
     py{37,38,39,310,311,312,py38}
-    flake8
 isolated_build = true
 
 [testenv]
@@ -10,8 +9,3 @@ deps =
     freezegun
     pytest
 commands = pytest --rich {posargs:tests}
-
-[testenv:flake8]
-skip_install = true
-deps = flake8
-commands = flake8 src/pytest_rich tests


### PR DESCRIPTION
In addition:


* Drop unused flake8 env from tox

  We rely on pre-commit.ci instead for flake checks.

* Drop tox-gh-actions

  We can just use '-e py' instead which will run whichever Python is found on PATH, which is enough for our CI needs.