### PR TITLE
fix: handle deeply nested failures without AssertionError

### DIFF
--- a/src/pytest_rich/traceback.py
+++ b/src/pytest_rich/traceback.py
@@ -199,10 +199,10 @@ class RichExceptionChainRepr:
             )
             yield text
 
-            assert entry.reprfuncargs is not None
-            args = get_args(entry.reprfuncargs)
-            if args:
-                yield args
+            if entry.reprfuncargs is not None:
+                args = get_args(entry.reprfuncargs)
+                if args:
+                    yield args
 
             code = read_code(filename)
             syntax = Syntax(

--- a/tests/example/test_basic.py
+++ b/tests/example/test_basic.py
@@ -67,38 +67,24 @@ def test_nested_failure():
     inner()
 
 
-# These two tests raise an `AssertionError`, so they are commented out
-# for now. They will be uncommented once the `AssertionError` is
-# handled.
-# Related issue: https://github.com/nicoddemus/pytest-rich/issues/44
-
-# def test_doubly_nested_failures():
-#     def inner():
-#         def inner_inner():
-#             assert False
-#         inner_inner()
-#     inner()
+def test_doubly_nested_failures():
+    def inner():
+        def inner_inner():
+            assert False
+        inner_inner()
+    inner()
 
 
-# def test_triply_nested_failures():
-#     def inner():
-#         def inner_inner():
-#             def inner_inner_inner():
-#                 assert False
-#             inner_inner_inner()
-#         inner_inner()
-#     inner()
+def test_triply_nested_failures():
+    def inner():
+        def inner_inner():
+            def inner_inner_inner():
+                assert False
+            inner_inner_inner()
+        inner_inner()
+    inner()
 
 
 def test_warning():
     warnings.warn("warning")
 
-
-def test_deep_nested_without_assertion_error():
-    def level3():
-        raise ValueError("Oops deeply nested")
-
-    def level2():
-        level3()
-
-    level2()

--- a/tests/example/test_basic.py
+++ b/tests/example/test_basic.py
@@ -71,7 +71,9 @@ def test_doubly_nested_failures():
     def inner():
         def inner_inner():
             assert False
+
         inner_inner()
+
     inner()
 
 
@@ -80,11 +82,13 @@ def test_triply_nested_failures():
         def inner_inner():
             def inner_inner_inner():
                 assert False
+
             inner_inner_inner()
+
         inner_inner()
+
     inner()
 
 
 def test_warning():
     warnings.warn("warning")
-

--- a/tests/example/test_basic.py
+++ b/tests/example/test_basic.py
@@ -92,3 +92,10 @@ def test_nested_failure():
 
 def test_warning():
     warnings.warn("warning")
+
+def test_deep_nested_without_assertion_error():
+    def level3():
+        raise ValueError("Oops deeply nested")
+    def level2():
+        level3()
+    level2()

--- a/tests/example/test_basic.py
+++ b/tests/example/test_basic.py
@@ -93,9 +93,12 @@ def test_nested_failure():
 def test_warning():
     warnings.warn("warning")
 
+
 def test_deep_nested_without_assertion_error():
     def level3():
         raise ValueError("Oops deeply nested")
+
     def level2():
         level3()
+
     level2()

--- a/tests/test_rich.py
+++ b/tests/test_rich.py
@@ -4,7 +4,7 @@ def test_outcomes(pytester):
     outcomes = {
         "passed": 3,
         "skipped": 4,
-        "failed": 2,
+        "failed": 3,
         "errors": 2,
         "xpassed": 1,
         "xfailed": 3,


### PR DESCRIPTION
## Problem
As reported in #44, failures occurring in nested functions beyond one level deep trigger an `AssertionError`. This happens because `entry.reprfuncargs` evaluates to `None` for intermediate call frames, and the code was previously asserting it to not be `None`.

## Solution
Updated `src/pytest_rich/traceback.py` to gracefully handle `entry.reprfuncargs` being `None` instead of raising an assertion error. 

## Testing
Manually created a deeply nested failure script resembling the one from the original issue, reproduced the failure, then verified that the fix correctly outputs the `pytest --rich` traceback without crashing. Verified that the existing test suite passes cleanly as well.

Closes #44