### PR TITLE
Fix traceback crashes on nested function failures

### DIFF
--- a/src/pytest_rich/traceback.py
+++ b/src/pytest_rich/traceback.py
@@ -91,8 +91,10 @@ class RichExceptionChainRepr:
 
         path_highlighter = PathHighlighter()
         for entry in self.chain.reprtraceback.reprentries:
-            assert isinstance(entry, ReprEntry)
-            assert isinstance(entry.reprfileloc, ReprFileLocation)
+            if not isinstance(entry, ReprEntry):
+                continue
+            if entry.reprfileloc is None:
+                continue
             if entry.reprfileloc.message:
                 yield Text.assemble(
                     path_highlighter(
@@ -182,8 +184,10 @@ class RichExceptionChainRepr:
             return err_lines
 
         for last, entry in loop_last(chain.reprtraceback.reprentries):
-            assert isinstance(entry, ReprEntry)
-            assert entry.reprfileloc is not None
+            if not isinstance(entry, ReprEntry):
+                continue
+            if entry.reprfileloc is None:
+                continue
             filename = entry.reprfileloc.path
             lineno = entry.reprfileloc.lineno
             funcname = get_funcname(lineno, filename)
@@ -199,10 +203,10 @@ class RichExceptionChainRepr:
             )
             yield text
 
-            assert entry.reprfuncargs is not None
-            args = get_args(entry.reprfuncargs)
-            if args:
-                yield args
+            if entry.reprfuncargs is not None:
+                args = get_args(entry.reprfuncargs)
+                if args:
+                    yield args
 
             code = read_code(filename)
             syntax = Syntax(

--- a/src/pytest_rich/traceback.py
+++ b/src/pytest_rich/traceback.py
@@ -5,7 +5,6 @@ from typing import Optional
 import attr
 from _pytest._code.code import ExceptionChainRepr
 from _pytest._code.code import ReprEntry
-from _pytest._code.code import ReprFileLocation
 from _pytest._code.code import ReprFuncArgs
 from pygments.token import Comment
 from pygments.token import Keyword

--- a/tests/example/test_basic.py
+++ b/tests/example/test_basic.py
@@ -71,7 +71,9 @@ def test_doubly_nested_failures():
     def inner():
         def inner_inner():
             assert False
+
         inner_inner()
+
     inner()
 
 
@@ -80,8 +82,11 @@ def test_triply_nested_failures():
         def inner_inner():
             def inner_inner_inner():
                 assert False
+
             inner_inner_inner()
+
         inner_inner()
+
     inner()
 
 

--- a/tests/example/test_basic.py
+++ b/tests/example/test_basic.py
@@ -67,27 +67,22 @@ def test_nested_failure():
     inner()
 
 
-# These two tests raise an `AssertionError`, so they are commented out
-# for now. They will be uncommented once the `AssertionError` is
-# handled.
-# Related issue: https://github.com/nicoddemus/pytest-rich/issues/44
-
-# def test_doubly_nested_failures():
-#     def inner():
-#         def inner_inner():
-#             assert False
-#         inner_inner()
-#     inner()
+def test_doubly_nested_failures():
+    def inner():
+        def inner_inner():
+            assert False
+        inner_inner()
+    inner()
 
 
-# def test_triply_nested_failures():
-#     def inner():
-#         def inner_inner():
-#             def inner_inner_inner():
-#                 assert False
-#             inner_inner_inner()
-#         inner_inner()
-#     inner()
+def test_triply_nested_failures():
+    def inner():
+        def inner_inner():
+            def inner_inner_inner():
+                assert False
+            inner_inner_inner()
+        inner_inner()
+    inner()
 
 
 def test_warning():

--- a/tests/test_rich.py
+++ b/tests/test_rich.py
@@ -1,13 +1,33 @@
 import pytest
 
 
+@pytest.fixture
+def rich_pytester(pytester):
+    """Register the Rich reporter alongside the standard one.
+
+    Using ``--rich`` is not enough because pytester captures stdout,
+    so ``sys.stdout.isatty()`` returns False and the plugin never activates.
+    """
+    pytester.makeconftest("""
+        import pytest
+        from pytest_rich.terminal import RichTerminalReporter
+
+        @pytest.hookimpl(trylast=True)
+        def pytest_configure(config):
+            config.pluginmanager.register(
+                RichTerminalReporter(config), "rich-terminal-reporter"
+            )
+    """)
+    return pytester
+
+
 def test_outcomes(pytester):
     pytester.copy_example("test_basic.py")
 
     outcomes = {
         "passed": 3,
         "skipped": 4,
-        "failed": 2,
+        "failed": 4,
         "errors": 2,
         "xpassed": 1,
         "xfailed": 3,
@@ -28,26 +48,6 @@ def test_collect_error(pytester):
     with_rich = pytester.runpytest("--rich")
 
     without_rich.assert_outcomes(errors=1) == with_rich.assert_outcomes(errors=1)
-
-
-@pytest.fixture
-def rich_pytester(pytester):
-    """Register the Rich reporter alongside the standard one.
-
-    Using ``--rich`` is not enough because pytester captures stdout,
-    so ``sys.stdout.isatty()`` returns False and the plugin never activates.
-    """
-    pytester.makeconftest("""
-        import pytest
-        from pytest_rich.terminal import RichTerminalReporter
-
-        @pytest.hookimpl(trylast=True)
-        def pytest_configure(config):
-            config.pluginmanager.register(
-                RichTerminalReporter(config), "rich-terminal-reporter"
-            )
-    """)
-    return pytester
 
 
 @pytest.mark.parametrize(
@@ -92,4 +92,50 @@ def test_skip_xfail_do_not_crash(
     result = rich_pytester.runpytest()
     assert result.ret == expected_ret
     result.assert_outcomes(**expected_outcomes)
+    result.stdout.fnmatch_lines(["*Summary*"])
+
+
+@pytest.mark.parametrize(
+    "test_code",
+    [
+        pytest.param(
+            """
+def test_nested():
+    def inner():
+        assert False
+    inner()
+""",
+            id="one-level",
+        ),
+        pytest.param(
+            """
+def test_nested():
+    def inner():
+        def inner_inner():
+            assert False
+        inner_inner()
+    inner()
+""",
+            id="two-levels",
+        ),
+        pytest.param(
+            """
+def test_nested():
+    def inner():
+        def inner_inner():
+            def inner_inner_inner():
+                assert False
+            inner_inner_inner()
+        inner_inner()
+    inner()
+""",
+            id="three-levels",
+        ),
+    ],
+)
+def test_nested_function_failures(rich_pytester, test_code):
+    rich_pytester.makepyfile(test_code)
+    result = rich_pytester.runpytest()
+    assert result.ret == 1
+    result.assert_outcomes(failed=1)
     result.stdout.fnmatch_lines(["*Summary*"])


### PR DESCRIPTION
Entries in pytest's traceback repr can be ReprEntryNative or have None fields (reprfuncargs, reprfileloc), skip them instead of asserting they exist.

Closes #44, closes #106.