### PR TITLE
Show collection errors instead of silently hiding them

### DIFF
--- a/src/pytest_rich/terminal.py
+++ b/src/pytest_rich/terminal.py
@@ -10,7 +10,6 @@ import attr
 import pytest
 from _pytest._code.code import ExceptionChainRepr
 from _pytest._code.code import ExceptionRepr
-from _pytest.reports import CollectErrorRepr
 from rich.console import Console
 from rich.live import Live
 from rich.padding import Padding
@@ -91,9 +90,13 @@ class RichTerminalReporter:
 
     def pytest_collection_finish(self, session: pytest.Session) -> None:
         if self.collect_progress is not None:
+            error_suffix = ""
+            if self.collection_errors:
+                n = len(self.collection_errors)
+                error_suffix = f" [red]/ {n} errors" if n > 1 else " [red]/ 1 error"
             self.collect_progress.update(
                 self.collect_task,
-                description=f"[cyan][bold]Collected [green]{self.total_items_collected} [cyan]items",
+                description=f"[cyan][bold]Collected [green]{self.total_items_collected} [cyan]items{error_suffix}",
                 completed=True,
             )
             self.collect_progress.stop()
@@ -239,17 +242,16 @@ class RichTerminalReporter:
             self.runtest_progress = None
             self.runtest_tasks_per_file.clear()
 
-        # Collection errors are always shown regardless of no_summary.
-        for index, report in enumerate(self.collection_errors):
-            if index == 0:
-                self.console.print(Rule("ERRORS", style="bold red"))
-            self.console.print(
-                Text(f"ERROR collecting {report.nodeid}", style="bold red")
-            )
-            if isinstance(report.longrepr, CollectErrorRepr):
-                self.console.print(Text(report.longrepr.longrepr, style="red"))
-            elif report.longrepr is not None:
-                self.console.print(Text(str(report.longrepr), style="red"))
+        if self.collection_errors:
+            self.console.print(Rule("ERRORS", style="bold red"))
+            for report in self.collection_errors:
+                self.console.print(
+                    Text(f"ERROR collecting {report.nodeid}", style="bold red")
+                )
+                if hasattr(report.longrepr, "longrepr"):
+                    self.console.print(Text(report.longrepr.longrepr, style="red"))
+                elif report.longrepr is not None:
+                    self.console.print(Text(str(report.longrepr), style="red"))
 
         if self.no_summary is False:
             error_messages = {}
@@ -276,7 +278,7 @@ class RichTerminalReporter:
                         )
                     )
 
-            if self.verbosity_level >= 0:
+            if self.verbosity_level >= 0 and self.total_items_completed > 0:
                 self.print_summary(error_messages)
 
         status = "SUCCEEDED" if exitstatus == 0 else "FAILED"
@@ -320,16 +322,14 @@ class RichTerminalReporter:
         for state, reports in self.categorized_reports.items():
             no_of_items = len(reports)
             if no_of_items > 0:
-                percentage = (
-                    f"({100 * no_of_items / self.total_items_completed:.1f}%)"
-                    if self.total_items_completed > 0
-                    else ""
-                )
                 summary_table.add_row(
                     Padding(str(no_of_items), pad=HORIZONTAL_PAD),
                     Padding(state.title(), pad=HORIZONTAL_PAD),
-                    Padding(percentage, pad=HORIZONTAL_PAD),
-                    style=style_dict.get(state, "bold red"),
+                    Padding(
+                        f"({100 * no_of_items / self.total_items_completed:.1f}%)",
+                        pad=HORIZONTAL_PAD,
+                    ),
+                    style=style_dict[state],
                 )
 
         if self.collection_errors:

--- a/src/pytest_rich/terminal.py
+++ b/src/pytest_rich/terminal.py
@@ -10,6 +10,7 @@ import attr
 import pytest
 from _pytest._code.code import ExceptionChainRepr
 from _pytest._code.code import ExceptionRepr
+from _pytest.reports import CollectErrorRepr
 from rich.console import Console
 from rich.live import Live
 from rich.padding import Padding
@@ -56,6 +57,7 @@ class RichTerminalReporter:
         self.runtest_tasks_per_file: dict[Path, TaskID] = {}
         self.categorized_reports: dict[str, list[pytest.TestReport]] = defaultdict(list)
         self.summary: Optional[Live] = None
+        self.collection_errors: list[pytest.CollectReport] = []
         self.total_duration: float = 0
         self.console.record = self.config.getoption("rich_capture") is not None
 
@@ -71,6 +73,8 @@ class RichTerminalReporter:
         self.collect_progress.start()
 
     def pytest_collectreport(self, report: pytest.CollectReport) -> None:
+        if report.failed:
+            self.collection_errors.append(report)
         items = [x for x in report.result if isinstance(x, pytest.Item)]
         if items:
             for item in items:
@@ -235,6 +239,18 @@ class RichTerminalReporter:
             self.runtest_progress = None
             self.runtest_tasks_per_file.clear()
 
+        # Collection errors are always shown regardless of no_summary.
+        for index, report in enumerate(self.collection_errors):
+            if index == 0:
+                self.console.print(Rule("ERRORS", style="bold red"))
+            self.console.print(
+                Text(f"ERROR collecting {report.nodeid}", style="bold red")
+            )
+            if isinstance(report.longrepr, CollectErrorRepr):
+                self.console.print(Text(report.longrepr.longrepr, style="red"))
+            elif report.longrepr is not None:
+                self.console.print(Text(str(report.longrepr), style="red"))
+
         if self.no_summary is False:
             error_messages = {}
             for index, report in enumerate(self.categorized_reports["failed"]):
@@ -304,22 +320,28 @@ class RichTerminalReporter:
         for state, reports in self.categorized_reports.items():
             no_of_items = len(reports)
             if no_of_items > 0:
-                summary_table.add_row(
-                    Padding(
-                        str(no_of_items),
-                        pad=HORIZONTAL_PAD,
-                    ),
-                    Padding(
-                        state.title(),
-                        pad=HORIZONTAL_PAD,
-                    ),
-                    Padding(
-                        f"({100 * no_of_items / self.total_items_completed:.1f}%)",
-                        pad=HORIZONTAL_PAD,
-                    ),
-                    #
-                    style=style_dict[state],
+                percentage = (
+                    f"({100 * no_of_items / self.total_items_completed:.1f}%)"
+                    if self.total_items_completed > 0
+                    else ""
                 )
+                summary_table.add_row(
+                    Padding(str(no_of_items), pad=HORIZONTAL_PAD),
+                    Padding(state.title(), pad=HORIZONTAL_PAD),
+                    Padding(percentage, pad=HORIZONTAL_PAD),
+                    style=style_dict.get(state, "bold red"),
+                )
+
+        if self.collection_errors:
+            summary_table.add_row(
+                Padding(
+                    str(len(self.collection_errors)),
+                    pad=HORIZONTAL_PAD,
+                ),
+                Padding("Collection Errors", pad=HORIZONTAL_PAD),
+                Padding("", pad=HORIZONTAL_PAD),
+                style="bold red",
+            )
 
         if self.verbose is True:
             for nodeid, status in self.status_per_item.items():

--- a/tests/test_rich.py
+++ b/tests/test_rich.py
@@ -39,14 +39,32 @@ def test_outcomes(pytester):
     without_rich.assert_outcomes(**outcomes) == with_rich.assert_outcomes(**outcomes)
 
 
+def test_collect_error_outcomes(pytester):
+    """Stock pytest must report collection errors as errors in outcomes."""
+    pytester.makepyfile("""
+    raise Exception("collect error")
+    """)
+    result = pytester.runpytest()
+    result.assert_outcomes(errors=1)
+
+
 def test_collect_error(rich_pytester):
     rich_pytester.makepyfile("""
     raise Exception("collect error")
     """)
     result = rich_pytester.runpytest()
     assert result.ret != 0
-    # "Collection Errors" in the summary is unique to the Rich reporter.
-    result.stdout.fnmatch_lines(["*ERROR collecting*", "*Collection Errors*"])
+    result.stdout.fnmatch_lines(["*ERROR collecting*"])
+
+
+def test_collect_error_shown_with_no_summary(rich_pytester):
+    """Collection errors must be visible even when --no-summary is used."""
+    rich_pytester.makepyfile("""
+    raise Exception("collect error")
+    """)
+    result = rich_pytester.runpytest("--no-summary")
+    assert result.ret != 0
+    result.stdout.fnmatch_lines(["*ERROR collecting*"])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_rich.py
+++ b/tests/test_rich.py
@@ -39,15 +39,14 @@ def test_outcomes(pytester):
     without_rich.assert_outcomes(**outcomes) == with_rich.assert_outcomes(**outcomes)
 
 
-def test_collect_error(pytester):
-    pytester.makepyfile("""
+def test_collect_error(rich_pytester):
+    rich_pytester.makepyfile("""
     raise Exception("collect error")
     """)
-
-    without_rich = pytester.runpytest()
-    with_rich = pytester.runpytest("--rich")
-
-    without_rich.assert_outcomes(errors=1) == with_rich.assert_outcomes(errors=1)
+    result = rich_pytester.runpytest()
+    assert result.ret != 0
+    # "Collection Errors" in the summary is unique to the Rich reporter.
+    result.stdout.fnmatch_lines(["*ERROR collecting*", "*Collection Errors*"])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Now it should display collection errors ( like ImportError, syntax errors).
- Collection errors are shown regardless of --no-summary flag
- Added collection error count to the summary table

Fixes #75 