### PR TITLE
Show captured stdout/stderr on test failures

### DIFF
--- a/src/pytest_rich/terminal.py
+++ b/src/pytest_rich/terminal.py
@@ -53,6 +53,7 @@ class RichTerminalReporter:
         self.items_per_file: dict[Path, list[pytest.Item]] = {}
         self.status_per_item: dict[str, RichTerminalReporter.Status] = {}
         self.items: dict[str, pytest.Item] = {}
+        self.nodeid_per_location: dict[tuple[str, Optional[int], str], str] = {}
         self.runtest_tasks_per_file: dict[Path, TaskID] = {}
         self.categorized_reports: dict[str, list[pytest.TestReport]] = defaultdict(list)
         self.summary: Optional[Live] = None
@@ -80,6 +81,7 @@ class RichTerminalReporter:
                 self.items_per_file.setdefault(item.path, []).append(item)
                 self.status_per_item[item.nodeid] = "collected"
                 self.items[item.nodeid] = item
+                self.nodeid_per_location[item.location] = item.nodeid
             self.total_items_collected += len(items)
             if self.collect_progress is not None:
                 self.collect_progress.update(
@@ -118,7 +120,19 @@ class RichTerminalReporter:
         nodeid: str,
     ) -> None: ...
 
-    def pytest_deselected(self, items: Sequence[pytest.Item]) -> None: ...
+    def pytest_deselected(self, items: Sequence[pytest.Item]) -> None:
+        # Deselected items never run, so drop them from the bookkeeping or the
+        # per-file progress would never reach 100%.
+        for item in items:
+            if self.items.pop(item.nodeid, None) is None:
+                continue
+            self.status_per_item.pop(item.nodeid, None)
+            self.nodeid_per_location.pop(item.location, None)
+            self.total_items_collected -= 1
+            per_file = self.items_per_file[item.path]
+            per_file.remove(item)
+            if not per_file:
+                del self.items_per_file[item.path]
 
     def pytest_plugin_registered(self, plugin) -> None: ...
 
@@ -132,7 +146,7 @@ class RichTerminalReporter:
             for fn in self.items_per_file:
                 total_items = self.items_per_file[fn]
                 task = self.runtest_progress.add_task(
-                    str(fn.relative_to(self.config.rootpath)),
+                    self._file_label(fn),
                     total=len(total_items),
                     visible=False,
                 )
@@ -162,12 +176,24 @@ class RichTerminalReporter:
             case unreachable:
                 assert_never(unreachable)
 
+    def _file_label(self, fn: Path) -> str:
+        # ``relative_to`` raises ValueError for tests collected from outside
+        # the rootdir (e.g. ``pytest ../sibling/tests``).
+        try:
+            return str(fn.relative_to(self.config.rootpath))
+        except ValueError:
+            return str(fn)
+
     def _update_task(self, nodeid: str):
-        base_fn = nodeid.split("::")[0]
-        fn = self.config.rootpath / base_fn
+        current_item = self.items.get(nodeid)
+        if current_item is None:
+            # A plugin's report hook rewrote ``nodeid`` into something we never
+            # collected (e.g. a display-only string). Nothing to update.
+            return
+        fn = current_item.path
         task = self.runtest_tasks_per_file[fn]
-        current_item = self.items[nodeid]
-        items = self.items_per_file[current_item.path]
+        base_fn = self._file_label(fn)
+        items = self.items_per_file[fn]
         chars = []
         statuses = []
         for item in items:
@@ -222,8 +248,14 @@ class RichTerminalReporter:
                 category = "failed"
             self._preserve_report(report, category)
         if status is not None:
-            self.status_per_item[report.nodeid] = status
-            self._update_task(report.nodeid)
+            # A plugin's makereport hook may have rewritten ``report.nodeid``
+            # into a display-only string (#74); recover the collected nodeid
+            # through ``report.location``, which plugins don't mutate.
+            nodeid = report.nodeid
+            if nodeid not in self.items:
+                nodeid = self.nodeid_per_location.get(report.location, nodeid)
+            self.status_per_item[nodeid] = status
+            self._update_task(nodeid)
 
     def pytest_runtest_logfinish(self) -> None:
         self.total_items_completed += 1

--- a/tests/test_plugin_compat.py
+++ b/tests/test_plugin_compat.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+
+def test_survives_makereport_hookwrapper_mutating_nodeid(rich_pytester):
+    """A plugin's makereport hookwrapper rewriting report.nodeid must not crash rich.
+
+    Regression test for #74: a hookwrapper that swaps ``report.nodeid`` for a
+    display-only string (e.g. to prepend a docstring) made ``_update_task``
+    derive a bogus file path and KeyError on ``runtest_tasks_per_file``,
+    aborting the whole run with an INTERNALERROR. The progress row must also
+    still advance — surviving the mutation by silently dropping updates is not
+    enough.
+    """
+    rich_pytester.makepyfile(nodeid_mutator="""
+        import pytest
+
+        @pytest.hookimpl(hookwrapper=True)
+        def pytest_runtest_makereport(item, call):
+            outcome = yield
+            report = outcome.get_result()
+            report.nodeid = f"custom docstring <- {report.nodeid.split('::')[0]}"
+    """)
+    rich_pytester.makepyfile("""
+        def test_one_plus_one_equals_2():
+            assert 1 == 1
+    """)
+    rich_pytester.syspathinsert()
+    result = rich_pytester.runpytest("-p", "nodeid_mutator")
+    result.stdout.no_fnmatch_line("*INTERNALERROR*")
+    result.stdout.fnmatch_lines(
+        ["*100%*test_survives_makereport_hookwrapper_mutating_nodeid.py*"]
+    )
+    assert result.ret == 0
+
+
+def test_progress_completes_with_deselected_tests(rich_pytester):
+    """Deselected tests must not keep the per-file progress below 100%."""
+    rich_pytester.makepyfile("""
+        def test_selected():
+            pass
+
+        def test_deselected():
+            pass
+    """)
+    result = rich_pytester.runpytest("-k", "test_selected")
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(
+        ["*100%*test_progress_completes_with_deselected_tests.py*"]
+    )


### PR DESCRIPTION
Fixes #77, #13

**Summary**

- Failed tests' captured output sections were never printed, unlike stock pytest. Fixed by rendering report.sections after the traceback, respecting --show-capture the same way the built-in reporter does — which also covers #13.